### PR TITLE
feat: Upgrade Selenium to 4.33.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,14 +28,14 @@ repositories {
 }
 
 group = 'com.testsigma'
-version = '1.2.22_cloud'
+version = '1.2.23_cloud'
 description = 'Testsigma Java SDK'
 java.sourceCompatibility = JavaVersion.VERSION_11
 
 dependencies {
     implementation 'org.projectlombok:lombok:1.18.20'
-    implementation 'org.seleniumhq.selenium:selenium-api:4.20.0'
-    implementation 'org.seleniumhq.selenium:selenium-java:4.20.0'
+    implementation 'org.seleniumhq.selenium:selenium-api:4.33.0'
+    implementation 'org.seleniumhq.selenium:selenium-java:4.33.0'
     implementation 'io.appium:java-client:9.2.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.testng:testng:7.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 group = 'com.testsigma'
-version = '1.2.23_cloud'
+version = '1.2.24_cloud'
 description = 'Testsigma Java SDK'
 java.sourceCompatibility = JavaVersion.VERSION_11
 
@@ -36,7 +36,7 @@ dependencies {
     implementation 'org.projectlombok:lombok:1.18.20'
     implementation 'org.seleniumhq.selenium:selenium-api:4.33.0'
     implementation 'org.seleniumhq.selenium:selenium-java:4.33.0'
-    implementation 'io.appium:java-client:9.2.2'
+    implementation 'io.appium:java-client:9.4.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.testng:testng:7.4.0'
     implementation 'org.json:json:20160810'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.testsigma
 POM_ARTIFACT_ID=testsigma-java-sdk
-VERSION_NAME=1.2.22_cloud
+VERSION_NAME=1.2.23_cloud
 
 POM_NAME=Testsigma Java SDK
 POM_DESCRIPTION=Testsigma Java SDK

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ RELEASE_SIGNING_ENABLED=true
 
 GROUP=com.testsigma
 POM_ARTIFACT_ID=testsigma-java-sdk
-VERSION_NAME=1.2.23_cloud
+VERSION_NAME=1.2.24_cloud
 
 POM_NAME=Testsigma Java SDK
 POM_DESCRIPTION=Testsigma Java SDK


### PR DESCRIPTION
This commit upgrades the Selenium framework dependencies from version 4.20.0 to 4.33.0. This update includes the latest features and bug fixes from Selenium.

The following dependencies were updated:
org.seleniumhq.selenium:selenium-api
org.seleniumhq.selenium:selenium-java

The project version has also been incremented to 1.2.23_cloud to incorporate these changes.