### PR TITLE
chore: add security vulnerability scan workflow and update gitignore

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,39 @@
+name: Security Vulnerability Scan
+
+on:
+  workflow_dispatch:
+
+jobs:
+  grype-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Java version
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+
+      - name: Download dependencies
+        run: ./gradlew dependencies --no-daemon
+
+      - name: Install Grype
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Run Grype vulnerability scanner
+        run: |
+          GRADLE_CACHE="$HOME/.gradle/caches/modules-2/files-2.1"
+          echo "Scanning Gradle cache: $(find $GRADLE_CACHE -name '*.jar' | wc -l) JARs found"
+          grype "dir:$GRADLE_CACHE" \
+            --output table
+          grype "dir:$GRADLE_CACHE" \
+            --output sarif > grype-results.sarif
+
+      - name: Upload scan results as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: grype-scan-results
+          path: 'grype-results.sarif'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 .gradle
 .idea
 .DS_STORE
+.claude/*


### PR DESCRIPTION
- Add Grype-based security scanning workflow (manually triggered)
- Ignore .claude/* in gitignore